### PR TITLE
Support using Nginx instead of Apache

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,10 @@
 - include: setup-apache.yml
   when: aegir_http_service_type == 'apache'
 
+# Ref.: http://community.aegirproject.org/installing/manual#Nginx_configuration
+- include: setup-nginx.yml
+  when: aegir_http_service_type == 'nginx'
+
 # Ref.: http://community.aegirproject.org/installing/manual#Sudo_configuration
 - name: Configure sudo for aegir user
   copy:
@@ -83,7 +87,7 @@
 
 # Ref.: # http://community.aegirproject.org/installing/manual#Running_hostmaster-install
 - name: Install Aegir front-end
-  command: "drush @none --yes hostmaster-install --debug --working-copy --aegir_db_host={{ aegir_db_host }} --aegir_db_user={{ mysql_root_username }} --aegir_db_pass={{ mysql_root_password }} --aegir_version={{ aegir_platform_version }} {{ aegir_frontend_url }} --strict=0 --root={{ aegir_root }}/hostmaster-{{ aegir_platform_version }}/"
+  command: "drush @none --yes hostmaster-install --http_service_type={{ aegir_http_service_type }} --debug --working-copy --aegir_db_host={{ aegir_db_host }} --aegir_db_user={{ mysql_root_username }} --aegir_db_pass={{ mysql_root_password }} --aegir_version={{ aegir_platform_version }} {{ aegir_frontend_url }} --strict=0 --root={{ aegir_root }}/hostmaster-{{ aegir_platform_version }}/"
   args:
     creates: "{{ aegir_root }}/hostmaster-{{ aegir_platform_version }}/sites/{{ aegir_frontend_url }}/"
   sudo: yes

--- a/tasks/setup-nginx.yml
+++ b/tasks/setup-nginx.yml
@@ -1,0 +1,9 @@
+---
+- name: Make Aegir's Nginx config available
+  file:
+    state: link
+    path: /etc/nginx/conf.d/aegir.conf
+    src: "{{ aegir_root }}/config/nginx.conf"
+    force: yes  # the target doesn't exist yet
+
+


### PR DESCRIPTION
Make use of setting aegir_http_service_type to "nginx" instead of the default "apache".

Depends on nginx and php-fpm to be installed previous to this role.

Example settings:

aegir_http_service_type: nginx

aegir_dependencies:
- php5-cli
- php5-gd
- php5-mysql
- postfix
- sudo
- rsync
- git
- unzip
