### PR TITLE
Replace defaults variables for Aegir MySQL user and password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ aegir_root: /var/aegir
 aegir_user: aegir
 aegir_web_group: www-data
 aegir_db_host: localhost
+aegir_db_user: {{ mysql_root_username | default('root') }}
+aegir_db_pass: {{ mysql_root_password | default('root') }}
 aegir_manage_dependencies: true
 aegir_dependencies:
   - apache2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,8 @@ aegir_root: /var/aegir
 aegir_user: aegir
 aegir_web_group: www-data
 aegir_db_host: localhost
-aegir_db_user: {{ mysql_root_username | default('root') }}
-aegir_db_pass: {{ mysql_root_password | default('root') }}
+aegir_db_user: "{{ mysql_root_username | default('root') }}"
+aegir_db_pass: "{{ mysql_root_password | default('root') }}"
 aegir_manage_dependencies: true
 aegir_dependencies:
   - apache2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
 
 # Ref.: # http://community.aegirproject.org/installing/manual#Running_hostmaster-install
 - name: Install Aegir front-end
-  command: "drush @none --yes hostmaster-install --debug --working-copy --aegir_db_host={{ aegir_db_host }} --aegir_db_user={{ mysql_root_username }} --aegir_db_pass={{ mysql_root_password }} --aegir_version={{ aegir_platform_version }} {{ aegir_frontend_url }} --strict=0 --root={{ aegir_root }}/hostmaster-{{ aegir_platform_version }}/"
+  command: "drush @none --yes hostmaster-install --debug --working-copy --aegir_db_host={{ aegir_db_host }} --aegir_db_user={{ aegir_db_user }} --aegir_db_pass={{ aegir_db_pass }} --aegir_version={{ aegir_platform_version }} {{ aegir_frontend_url }} --strict=0 --root={{ aegir_root }}/hostmaster-{{ aegir_platform_version }}/"
   args:
     creates: "{{ aegir_root }}/hostmaster-{{ aegir_platform_version }}/sites/{{ aegir_frontend_url }}/"
   sudo: yes


### PR DESCRIPTION
We use _aegir__ prefix, so it does not collides with other roles.

For example, geerlingguy.mysql uses the same variable name.
